### PR TITLE
Reduced time collecting beacon data to 2 seconds and take an average.

### DIFF
--- a/BLEKit/Private/BLEBeaconsRangeBatch.m
+++ b/BLEKit/Private/BLEBeaconsRangeBatch.m
@@ -28,10 +28,10 @@
 
 #import "BLEBeaconsRangeBatch.h"
 
-#define BLERangingSecondsTimeFrame 2
+#define BLERangingSecondsTimeFrame 0
 
 // timeout value since last read. After that amount of time batch is cheared out
-#define BLERangingSecondsTimeout 120
+#define BLERangingSecondsTimeout 2
 
 static NSDate *lastRanging;
 


### PR DESCRIPTION
Updates faster, beacons drop off faster when out of range, and takes an average of the last beacons reported seen.
